### PR TITLE
Added Spiked monster predicates

### DIFF
--- a/src/data/imbues/strange-and-unusual/spiked.ts
+++ b/src/data/imbues/strange-and-unusual/spiked.ts
@@ -21,11 +21,34 @@ export function createImbueSpiked(): MaterialData {
         },
         description: { type: "key", key: lkey("description") },
         itemPredicate: ["item:type:armor"],
-        monsterPredicate: ["never"],
-        /*monsterPredicate: [
-            { or: ["item:damage:type:piercing", "item:damage:type:slashing"] },
-            "item:type:melee",
-        ],*/
+		monsterPredicate: [
+			{
+				"and": [
+					"item:type:action",
+					{
+						"or": [
+							"item:action:type:reaction",
+							"item:action:type:free",
+							{
+								"not": {
+									"or": [
+										"item:action:cost:1",
+										"item:action:cost:2",
+										"item:action:cost:3"
+									]
+								}
+							}
+						]
+					},
+					{
+						"or": [
+							"item:damage:type:slashing",
+							"item:damage:type:piercing"
+						]
+					}
+				]
+			}
+		],
         header: {
             description: {
                 type: "key",


### PR DESCRIPTION
Tested as a homebrew imbuement. Adds the correct monsterpredicates for the Spiked armor imbuement: Monsters with passive actions, reactions or free actions which deal piercing or slashing damage.

Unfortunately, `item:action:type:passive` doesn't exist, so instead this checks for any actions which do *not* cost 1, 2 or 3